### PR TITLE
Allow caling to() and cc() with zero arguments in Courriel::Builder

### DIFF
--- a/lib/Courriel/Builder.pm
+++ b/lib/Courriel/Builder.pm
@@ -183,7 +183,7 @@ sub _add_required_headers {
 
 {
     my $validator = validation_for(
-        params => [ { type => EmailAddressStr } ],
+        params => [ { type => EmailAddressStr, optional => 1 } ],
         slurpy => EmailAddressStr,
     );
 
@@ -198,7 +198,7 @@ sub _add_required_headers {
 
 {
     my $validator = validation_for(
-        params => [ { type => EmailAddressStr } ],
+        params => [ { type => EmailAddressStr, optional => 1 } ],
         slurpy => EmailAddressStr,
     );
 
@@ -496,12 +496,12 @@ an empty string, but not C<undef>.
 This sets the From header of the email. It expects a single string or
 an object with a C<format()> method like C<Email::Address::XS>.
 
-=head2 to($from)
+=head2 to($to, ... )
 
 This sets the To header of the email. It expects a list of strings and/or
 objects with a C<format()> method like C<Email::Address::XS>.
 
-=head2 cc($from)
+=head2 cc($cc, ... )
 
 This sets the Cc header of the email. It expects a list of strings and/or
 objects with a C<format()> method like C<Email::Address::XS>.

--- a/t/Builder.t
+++ b/t/Builder.t
@@ -99,6 +99,21 @@ use Sys::Hostname qw( hostname );
 }
 
 {
+    my $email = build_email(
+        cc(),
+        plain_body(
+            content => 'Foo',
+        ),
+    );
+
+    is_deeply(
+        [ map { $_->value } $email->headers->get('Cc') ],
+        [],
+        'got no recipients for the Cc header',
+    );
+}
+
+{
     my $dt = DateTime->new(
         year      => 1980,
         month     => 1,


### PR DESCRIPTION
Currently, `to()` and `cc()` require at least one argument, otherwise they'd fail like this:

```
Got 0 parameters but expected at least 1 for an un-named validation subroutine

Trace begun at (eval 1226) line 8
Eval::Closure::Sandbox_750::__ANON__ at /usr/local/share/perl/5.18.2/Courriel/Builder.pm line 206
Courriel::Builder::cc at foo.pl line 49
```

However, since the `build_email()` syntax is not very OOP and does not make conditional building easy, a quick way for adding recipients only when we have them is needed. In case we supply an empty list, I'd just expect `to()` and `cc()` to behave as no-ops.

This pull request leverages the `optional` argument provided by Params::ValidationCompiler.